### PR TITLE
人口（population）をグローバルステートとして扱えるようにする

### DIFF
--- a/src/features/populations/apis/populationApi.ts
+++ b/src/features/populations/apis/populationApi.ts
@@ -1,0 +1,24 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/dist/query/react'
+import RESAS_API from '@/consts/api'
+import { PrefecturePopulation } from '../types/Population'
+import { ResasResponse } from '@/types/ResasResponse'
+
+export const populationApi = createApi({
+  reducerPath: 'populationApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: RESAS_API.baseURL,
+  }),
+  endpoints: (builder) => ({
+    fetchPopulation: builder.query<PrefecturePopulation, number>({
+      query: (prefCode: number) => ({
+        url: 'population',
+        params: {
+          prefCode,
+        },
+      }),
+      transformResponse: (response: ResasResponse<PrefecturePopulation>) => response.result,
+    }),
+  }),
+})
+
+export const { useFetchPopulationQuery, useLazyFetchPopulationQuery } = populationApi

--- a/src/features/populations/types/Population.ts
+++ b/src/features/populations/types/Population.ts
@@ -1,0 +1,17 @@
+export type PrefecturePopulation = {
+  prefCode: number
+  boundaryYear: number
+  data: Population[]
+}
+
+export type Population = {
+  label: PopulationLabel
+  data: PopulationData[]
+}
+
+export type PopulationLabel = '総人口' | '年少人口' | '生産年齢人口' | '老年人口'
+
+export type PopulationData = {
+  year: number
+  value: number
+}

--- a/src/features/prefectures/apis/prefectureApi.ts
+++ b/src/features/prefectures/apis/prefectureApi.ts
@@ -1,11 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import RESAS_API from '@/consts/api'
 import { Prefecture } from '../types/Prefecture'
-
-export type FetchPrefecturesResponse = {
-  message?: string
-  result: Prefecture[]
-}
+import { ResasResponse } from '@/types/ResasResponse'
 
 export const prefectureApi = createApi({
   reducerPath: 'prefectureApi',
@@ -15,7 +11,7 @@ export const prefectureApi = createApi({
   endpoints: (builder) => ({
     fetchPrefectures: builder.query<Prefecture[], void>({
       query: () => 'prefectures',
-      transformResponse: (response: FetchPrefecturesResponse) => response.result,
+      transformResponse: (response: ResasResponse<Prefecture[]>) => response.result,
     }),
   }),
 })

--- a/src/features/prefectures/components/PrefectureCheckbox.tsx
+++ b/src/features/prefectures/components/PrefectureCheckbox.tsx
@@ -1,10 +1,18 @@
 import { usePrefecture } from '../hooks/usePrefecture'
 import { Prefecture } from '../types/Prefecture'
+import { useCallback } from 'react'
+import { useLazyFetchPopulationQuery } from '@/features/populations/apis/populationApi'
 
 export type PrefectureCheckboxProps = { prefecture: Prefecture }
 
 export const PrefectureCheckbox: React.FC<PrefectureCheckboxProps> = ({ prefecture }) => {
   const { togglePrefectureSelection } = usePrefecture(prefecture.prefCode)
+  const [trigger] = useLazyFetchPopulationQuery()
+
+  const handleChange = useCallback(async () => {
+    togglePrefectureSelection()
+    await trigger(prefecture.prefCode, true)
+  }, [prefecture.prefCode])
 
   return (
     <div>
@@ -12,7 +20,7 @@ export const PrefectureCheckbox: React.FC<PrefectureCheckboxProps> = ({ prefectu
         type="checkbox"
         name="prefecture"
         id={prefecture.prefCode.toString()}
-        onChange={togglePrefectureSelection}
+        onChange={handleChange}
         checked={prefecture.isSelected}
       />
       <label htmlFor={prefecture.prefCode.toString()}>{prefecture.prefName}</label>

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,12 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { useSelector, TypedUseSelectorHook, useDispatch } from 'react-redux'
 import { prefectureApi } from '@/features/prefectures/apis/prefectureApi'
+import { populationApi } from '@/features/populations/apis/populationApi'
 
 export const store = configureStore({
   reducer: {
     [prefectureApi.reducerPath]: prefectureApi.reducer,
+    [populationApi.reducerPath]: populationApi.reducer,
   },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat([prefectureApi.middleware]),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat([prefectureApi.middleware, populationApi.middleware]),
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/src/types/ResasResponse.ts
+++ b/src/types/ResasResponse.ts
@@ -1,0 +1,4 @@
+export type ResasResponse<T> = {
+  message?: string
+  result: T
+}


### PR DESCRIPTION
## 関連Issue
closes: #8

## やったこと
- Populationの型を定義
- RTX QueryでAPIを作成
- コンポーネントから使ってみる
- キャッシュが機能しているか確認（ネットワークタブの通信状況を監視する）

checkboxを選択したときに毎回fetchのtriggerが走るが、RTK Queryを使っているため一度取得していればキャッシュからデータを取得するため通信は発生しない