### PR TITLE
都道府県のチェックボックスを連続して2回クリックするとグラフの表示が正しくなくなる不具合を修正

### DIFF
--- a/src/features/prefectures/components/PrefectureCheckbox.tsx
+++ b/src/features/prefectures/components/PrefectureCheckbox.tsx
@@ -11,8 +11,8 @@ export const PrefectureCheckbox: React.FC<PrefectureCheckboxProps> = ({ prefectu
   const [trigger] = useLazyFetchPopulationQuery()
 
   const handleChange = useCallback(async () => {
-    togglePrefectureSelection()
     await trigger(prefecture.prefCode, true)
+    togglePrefectureSelection()
   }, [prefecture.prefCode])
 
   return (


### PR DESCRIPTION
## 関連Issue
closes: #21 