### PR TITLE
人口カテゴリ（「総人口」「年少人口」「生産年齢人口」「老年人口」）別にグラフを切り替えられるUIを実装する総人口」「年少人口」「生産年齢人口」「老年人口」）別にグラフを切り替えられるUIを実装した

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { PopulationLineChart } from './features/populations/components/Populatio
 import { Container } from './components/layouts/Container'
 import { Card } from './components/card'
 import { PrefectureGeoChart } from './features/prefectures/components/PrefectureGeoChart'
+import { CardTabs } from './components/card/CardTabs'
+import { CardTab } from './components/card/CardTab'
 
 const App = () => {
   return (
@@ -27,6 +29,12 @@ const App = () => {
                 </div>
               </div>
               <Card>
+                <CardTabs value="総人口" onChange={() => {}}>
+                  <CardTab value="総人口">総人口</CardTab>
+                  <CardTab value="年少人口">年少人口</CardTab>
+                  <CardTab value="生産年齢人口">生産年齢人口</CardTab>
+                  <CardTab value="老年人口">老年人口</CardTab>
+                </CardTabs>
                 <PopulationLineChart />
               </Card>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,7 @@ import { PopulationLineChart } from './features/populations/components/Populatio
 import { Container } from './components/layouts/Container'
 import { Card } from './components/card'
 import { PrefectureGeoChart } from './features/prefectures/components/PrefectureGeoChart'
-import { CardTabs } from './components/card/CardTabs'
-import { CardTab } from './components/card/CardTab'
+import { PopulationCategoryCardTabs } from './features/populations/components/PopulationCategoryTabs'
 
 const App = () => {
   return (
@@ -29,12 +28,7 @@ const App = () => {
                 </div>
               </div>
               <Card>
-                <CardTabs value="総人口" onChange={() => {}}>
-                  <CardTab value="総人口">総人口</CardTab>
-                  <CardTab value="年少人口">年少人口</CardTab>
-                  <CardTab value="生産年齢人口">生産年齢人口</CardTab>
-                  <CardTab value="老年人口">老年人口</CardTab>
-                </CardTabs>
+                <PopulationCategoryCardTabs />
                 <PopulationLineChart />
               </Card>
             </div>

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -9,9 +9,13 @@ export const Card: React.FC<CardProps> = ({ children }) => {
 }
 
 const card = css`
-  padding: 2rem 3rem;
+  padding: 2rem 1rem;
   border-radius: 1rem;
   background-color: ${theme.colors.white};
   box-shadow: rgba(67, 133, 187, 0.07) 0px 8px 12px 0px;
   position: relative;
+
+  @media screen and (min-width: 768px) {
+    padding: 2rem 3rem;
+  }
 `

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -1,4 +1,6 @@
+import { theme } from '@/theme'
 import { css } from '@emotion/react'
+import React from 'react'
 
 export type CardProps = { children: React.ReactNode }
 
@@ -9,6 +11,7 @@ export const Card: React.FC<CardProps> = ({ children }) => {
 const card = css`
   padding: 2rem 3rem;
   border-radius: 1rem;
-  background-color: #fff;
+  background-color: ${theme.colors.white};
   box-shadow: rgba(67, 133, 187, 0.07) 0px 8px 12px 0px;
+  position: relative;
 `

--- a/src/components/card/CardTab.tsx
+++ b/src/components/card/CardTab.tsx
@@ -25,8 +25,13 @@ const tab = css`
   border: none;
   border-radius: 0.5rem 0.5rem 0 0;
   height: 44px;
-  padding: 0 1rem;
+  padding: 0 0.75rem;
+  margin-top: 0.25rem;
   cursor: pointer;
+
+  @media screen and (min-width: 768px) {
+    padding: 0 1rem;
+  }
 `
 
 const tabSelected = css`

--- a/src/components/card/CardTab.tsx
+++ b/src/components/card/CardTab.tsx
@@ -1,0 +1,48 @@
+import { theme } from '@/theme'
+import { css } from '@emotion/react'
+
+export type CardTabProps = {
+  children: React.ReactNode
+  value: string
+  selected?: boolean
+  onClick?: () => void
+}
+
+export const CardTab: React.FC<CardTabProps> = ({ children, selected = false, onClick }) => {
+  return (
+    <button
+      css={[tab, selected && tabSelected]}
+      onClick={onClick}
+      role="tab"
+      aria-selected={selected}>
+      {children}
+    </button>
+  )
+}
+
+const tab = css`
+  background-color: ${theme.colors.white};
+  border: none;
+  border-radius: 0.5rem 0.5rem 0 0;
+  height: 44px;
+  padding: 0 1rem;
+  cursor: pointer;
+`
+
+const tabSelected = css`
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 0px 4px 0px;
+  position: relative;
+  font-weight: bold;
+  color: ${theme.colors.green};
+
+  &:before {
+    content: '';
+    display: block;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    position: absolute;
+    box-shadow: ${theme.colors.white} 0px 10px 0px 1px;
+  }
+`

--- a/src/components/card/CardTabs.tsx
+++ b/src/components/card/CardTabs.tsx
@@ -1,0 +1,31 @@
+import { theme } from '@/theme'
+import { css } from '@emotion/react'
+import React from 'react'
+import { CardTabProps } from './CardTab'
+
+export type CardTabsProps = {
+  children: React.ReactNode
+  value?: string
+  onChange: (value: string) => void
+}
+
+export const CardTabs: React.FC<CardTabsProps> = ({ children, value, onChange }) => {
+  return (
+    <div css={tablist} role="tablist">
+      {React.Children.map(children, (child) =>
+        React.cloneElement(child as React.ReactElement<CardTabProps>, {
+          selected: value === (child as React.ReactElement<CardTabProps>).props.value,
+          onClick: () => value && onChange(value),
+        })
+      )}
+    </div>
+  )
+}
+
+const tablist = css`
+  margin: -1rem -3rem 1rem;
+  padding: 0 1rem;
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid ${theme.colors.border};
+`

--- a/src/components/card/CardTabs.tsx
+++ b/src/components/card/CardTabs.tsx
@@ -23,9 +23,21 @@ export const CardTabs: React.FC<CardTabsProps> = ({ children, value, onChange })
 }
 
 const tablist = css`
-  margin: -1rem -3rem 1rem;
+  margin: -1rem -1rem 1rem;
   padding: 0 1rem;
   display: flex;
-  gap: 0.5rem;
+
   border-bottom: 1px solid ${theme.colors.border};
+  overflow-x: scroll;
+  white-space: nowrap;
+
+  &::-webkit-scrollbar {
+    background-color: transparent;
+    height: 0;
+  }
+
+  @media screen and (min-width: 768px) {
+    margin: -1rem -3rem 1rem;
+    gap: 0.5rem;
+  }
 `

--- a/src/components/card/CardTabs.tsx
+++ b/src/components/card/CardTabs.tsx
@@ -15,7 +15,7 @@ export const CardTabs: React.FC<CardTabsProps> = ({ children, value, onChange })
       {React.Children.map(children, (child) =>
         React.cloneElement(child as React.ReactElement<CardTabProps>, {
           selected: value === (child as React.ReactElement<CardTabProps>).props.value,
-          onClick: () => value && onChange(value),
+          onClick: () => value && onChange((child as React.ReactElement<CardTabProps>).props.value),
         })
       )}
     </div>

--- a/src/features/populations/components/PopulationCategoryTabs.tsx
+++ b/src/features/populations/components/PopulationCategoryTabs.tsx
@@ -1,0 +1,25 @@
+import { CardTab } from '@/components/card/CardTab'
+import { CardTabs } from '@/components/card/CardTabs'
+import { useAppSelector, useAppDispatch } from '@/stores/store'
+import { selectPopulationCategory } from '../stores/SelectedPopulationCategory'
+import { PopulationLabel } from '../types/Population'
+
+export type PopulationCategoryCardTabsProps = {}
+
+export const PopulationCategoryCardTabs: React.FC<PopulationCategoryCardTabsProps> = () => {
+  const selectedPopulationCategory = useAppSelector(
+    (state) => state.selectedPopulationCategory.selected
+  )
+  const dispatch = useAppDispatch()
+
+  return (
+    <CardTabs
+      value={selectedPopulationCategory}
+      onChange={(value) => dispatch(selectPopulationCategory(value as PopulationLabel))}>
+      <CardTab value="総人口">総人口</CardTab>
+      <CardTab value="年少人口">年少人口</CardTab>
+      <CardTab value="生産年齢人口">生産年齢人口</CardTab>
+      <CardTab value="老年人口">老年人口</CardTab>
+    </CardTabs>
+  )
+}

--- a/src/features/populations/hooks/usePopulationLineChart.ts
+++ b/src/features/populations/hooks/usePopulationLineChart.ts
@@ -25,7 +25,7 @@ export const usePopulationLineChart = () => {
       sizeAxis: { maxValue: 1 },
       backgroundColor: theme.colors.background,
       datalessRegionColor: theme.colors.background,
-      colors: isSelected ? ['#fff', 'green'] : ['#fff'],
+      colors: isSelected ? [theme.colors.white, theme.colors.green] : [theme.colors.white],
       tooltip: {
         trigger: 'none', // ツールチップを非表示にする
       },

--- a/src/features/populations/stores/SelectedPopulationCategory.ts
+++ b/src/features/populations/stores/SelectedPopulationCategory.ts
@@ -1,0 +1,19 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { PopulationLabel } from '../types/Population'
+
+const initialState: { selected: PopulationLabel } = { selected: '総人口' }
+
+const selectedPopulationCategorySlice = createSlice({
+  name: 'populationCategories',
+  initialState,
+  reducers: {
+    selectPopulationCategory: (state, action: PayloadAction<PopulationLabel>) => {
+      state.selected = action.payload
+      console.log(action.payload)
+    },
+  },
+})
+
+export const { selectPopulationCategory } = selectedPopulationCategorySlice.actions
+
+export const selectedPopulationCategoryReducer = selectedPopulationCategorySlice.reducer

--- a/src/features/populations/stores/SelectedPopulationCategory.ts
+++ b/src/features/populations/stores/SelectedPopulationCategory.ts
@@ -9,7 +9,6 @@ const selectedPopulationCategorySlice = createSlice({
   reducers: {
     selectPopulationCategory: (state, action: PayloadAction<PopulationLabel>) => {
       state.selected = action.payload
-      console.log(action.payload)
     },
   },
 })

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -2,11 +2,13 @@ import { configureStore } from '@reduxjs/toolkit'
 import { useSelector, TypedUseSelectorHook, useDispatch } from 'react-redux'
 import { prefectureApi } from '@/features/prefectures/apis/prefectureApi'
 import { populationApi } from '@/features/populations/apis/populationApi'
+import { selectedPopulationCategoryReducer } from '@/features/populations/stores/SelectedPopulationCategory'
 
 export const store = configureStore({
   reducer: {
     [prefectureApi.reducerPath]: prefectureApi.reducer,
     [populationApi.reducerPath]: populationApi.reducer,
+    selectedPopulationCategory: selectedPopulationCategoryReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat([prefectureApi.middleware, populationApi.middleware]),

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,9 @@
 export const colors = {
+  // base
+  white: '#fff',
+  green: '#00a760',
+
+  // topic
   background: '#f5f6f6',
   border: 'rgba(92, 147, 187, 0.17)',
 }


### PR DESCRIPTION
## 関連Issue
closes #24 

## やったこと
- [x] Cardコンポーネントをタブに対応させる
- [x] 人口カテゴリとしてグラフのCardで表示する
- [x] redux-toolkitでどの人口カテゴリが選択されているかを管理するグローバルステートを作成する
- [x] タブの切り替えでグラフの表示が切り替わるようにロジック部分を実装する

- [x] タブのレスポンシブ対応